### PR TITLE
feat: use more general type for header parameter

### DIFF
--- a/.changeset/old-forks-rush.md
+++ b/.changeset/old-forks-rush.md
@@ -1,0 +1,5 @@
+---
+"@portone/server-sdk": patch
+---
+
+Use more general type for the header parameter

--- a/packages/server-sdk/src/webhook.ts
+++ b/packages/server-sdk/src/webhook.ts
@@ -41,6 +41,31 @@ export interface WebhookOptions {
 const prefix = "whsec_";
 
 /**
+ * returns the value only when there is only one string entry with the name (case-insensitive)
+ */
+function findHeaderValue(
+	headers: unknown,
+	name: string,
+): string | undefined {
+	if (typeof headers !== 'object' || headers === null) return undefined;
+
+	const nameLowerCase = name.toLowerCase()
+
+	let found: string | undefined = undefined;
+	for (const [key, value] of Object.entries(headers)) {
+		if (key.toLowerCase() === nameLowerCase && value != null) {
+			for (const v of Array.isArray(value) ? value : [value]) {
+				if (v == null) continue;                     // ignore null or undefined
+				if (typeof v !== 'string') return undefined; // non-string values are illegal
+				if (found !== undefined) return undefined;   // having duplicate entries is illegal
+				found = v;
+			}
+		}
+	}
+	return found;
+}
+
+/**
  * 웹훅 페이로드를 검증합니다.
  *
  * @param secret 웹훅 시크릿
@@ -53,20 +78,13 @@ const prefix = "whsec_";
 export async function verify(
 	secret: string | Uint8Array,
 	payload: string,
-	headers: WebhookUnbrandedRequiredHeaders | Record<string, string>,
+	headers: WebhookUnbrandedRequiredHeaders | Record<string, string | string[] | undefined>,
 ): Promise<void> {
-	const mappedHeaders: Record<string, string> = Object.fromEntries(
-		Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
-	);
-
-	const msgId = mappedHeaders["webhook-id"];
-	const msgSignature = mappedHeaders["webhook-signature"];
-	const msgTimestamp = mappedHeaders["webhook-timestamp"];
+	const msgId = findHeaderValue(headers, "webhook-id");
+	const msgSignature = findHeaderValue(headers, "webhook-signature");
+	const msgTimestamp = findHeaderValue(headers, "webhook-timestamp");
 
 	if (
-		typeof msgId !== "string" ||
-		typeof msgSignature !== "string" ||
-		typeof msgTimestamp !== "string" ||
 		!msgId ||
 		!msgSignature ||
 		!msgTimestamp

--- a/packages/server-sdk/src/webhook.ts
+++ b/packages/server-sdk/src/webhook.ts
@@ -43,21 +43,18 @@ const prefix = "whsec_";
 /**
  * returns the value only when there is only one string entry with the name (case-insensitive)
  */
-function findHeaderValue(
-	headers: unknown,
-	name: string,
-): string | undefined {
-	if (typeof headers !== 'object' || headers === null) return undefined;
+function findHeaderValue(headers: unknown, name: string): string | undefined {
+	if (typeof headers !== "object" || headers === null) return undefined;
 
-	const nameLowerCase = name.toLowerCase()
+	const nameLowerCase = name.toLowerCase();
 
 	let found: string | undefined = undefined;
 	for (const [key, value] of Object.entries(headers)) {
-		if (key.toLowerCase() === nameLowerCase && value != null) {
+		if (key.toLowerCase() === nameLowerCase) {
 			for (const v of Array.isArray(value) ? value : [value]) {
-				if (v == null) continue;                     // ignore null or undefined
-				if (typeof v !== 'string') return undefined; // non-string values are illegal
-				if (found !== undefined) return undefined;   // having duplicate entries is illegal
+				if (v == null) continue; // ignore null or undefined
+				if (typeof v !== "string") return undefined; // non-string values are illegal
+				if (found !== undefined) return undefined; // having duplicate entries is illegal
 				found = v;
 			}
 		}
@@ -78,17 +75,15 @@ function findHeaderValue(
 export async function verify(
 	secret: string | Uint8Array,
 	payload: string,
-	headers: WebhookUnbrandedRequiredHeaders | Record<string, string | string[] | undefined>,
+	headers:
+		| WebhookUnbrandedRequiredHeaders
+		| Record<string, string | string[] | undefined>,
 ): Promise<void> {
 	const msgId = findHeaderValue(headers, "webhook-id");
 	const msgSignature = findHeaderValue(headers, "webhook-signature");
 	const msgTimestamp = findHeaderValue(headers, "webhook-timestamp");
 
-	if (
-		!msgId ||
-		!msgSignature ||
-		!msgTimestamp
-	) {
+	if (!msgId || !msgSignature || !msgTimestamp) {
 		throw new WebhookVerificationError("MISSING_REQUIRED_HEADERS");
 	}
 


### PR DESCRIPTION
To allow @types/node IncomingHttpHeaders object to be passed without casting, use Record<string, string | string[] | undefined>.